### PR TITLE
Dash rm redundand kpis

### DIFF
--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -123,6 +123,7 @@ class Dashboard extends CI_Controller {
 
 		// Country stats
 		$data['total_countries'] = $stats['Countries_Worked'];
+			$data['unique_callsigns'] = $stats['Unique_Callsigns'];
 		$data['total_countries_confirmed_paper'] = $stats['Countries_Worked_QSL'];
 		$data['total_countries_confirmed_eqsl'] = $stats['Countries_Worked_EQSL'];
 		$data['total_countries_confirmed_lotw'] = $stats['Countries_Worked_LOTW'];

--- a/application/controllers/Dashboard.php
+++ b/application/controllers/Dashboard.php
@@ -104,12 +104,19 @@ class Dashboard extends CI_Controller {
 		$data['month_qsos'] = $qso_counts['month'];
 		$data['year_qsos'] = $qso_counts['year'];
 
-		$rawstreak=$this->dayswithqso_model->getAlmostCurrentStreak();
+		$rawstreak=$this->dayswithqso_model->getCurrentStreak();
 		if (is_array($rawstreak)) {
 			$data['current_streak']=$rawstreak['highstreak'];
 		} else {
-			$data['current_streak']=0;
+			$rawstreak=$this->dayswithqso_model->getAlmostCurrentStreak();
+			if (is_array($rawstreak)) {
+				$data['current_streak']=$rawstreak['highstreak'];
+			} else {
+				$data['current_streak']=0;
+			}
 		}
+
+		$data['almost_current_streak']=$data['current_streak'];
 
 		// Load Dashboard stats (countries + QSL stats in one query)
 		$stats = $this->logbook_model->dashboard_stats_batch($logbooks_locations_array);

--- a/application/models/Logbook_model.php
+++ b/application/models/Logbook_model.php
@@ -4359,6 +4359,8 @@ class Logbook_model extends CI_Model {
 
 			$sql = "SELECT
 				-- Country stats (COUNT DISTINCT - filtered to valid DXCC only)
+				-- Callsign stats
+				COUNT(DISTINCT t.COL_CALL) as Unique_Callsigns,
 				COUNT(DISTINCT CASE WHEN t.COL_COUNTRY != 'Invalid' AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked,
 				COUNT(DISTINCT CASE WHEN t.COL_QSL_RCVD = 'Y' AND t.COL_COUNTRY != 'Invalid' AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked_QSL,
 				COUNT(DISTINCT CASE WHEN t.COL_EQSL_QSL_RCVD = 'Y' AND t.COL_COUNTRY != 'Invalid' AND t.COL_DXCC > 0 THEN t.COL_DXCC END) as Countries_Worked_EQSL,
@@ -4398,6 +4400,7 @@ class Logbook_model extends CI_Model {
 				$row = $query->row();
 				return [
 					// Country stats
+				'Unique_Callsigns' => $row->Unique_Callsigns,
 					'Countries_Worked' => $row->Countries_Worked,
 					'Countries_Worked_QSL' => $row->Countries_Worked_QSL,
 					'Countries_Worked_EQSL' => $row->Countries_Worked_EQSL,

--- a/application/views/dashboard/index.php
+++ b/application/views/dashboard/index.php
@@ -207,8 +207,8 @@ function echo_table_header_col($name) {
 	<?php } else { ?>
 		<div class="alert alert-warning alert-dismissible fade show" role="alert" style="margin-top: 1rem;">
 			<span class="badge text-bg-info"><?= __("Important"); ?></span> <i class="fas fa-broadcast-tower"></i>
-			<?php if (($current_streak ?? 0)>0) {
-				echo sprintf(__("Don't lose your streak - You have already had at least one QSO for the last %s consecutive days."),$current_streak);
+			<?php if (($almost_current_streak ?? 0)>0) {
+				echo sprintf(__("Don't lose your streak - You have already had at least one QSO for the last %s consecutive days."),$almost_current_streak);
 			} else {
 				echo __("You have made no QSOs today; time to turn on the radio!");
 			} ?>
@@ -299,10 +299,10 @@ function echo_table_header_col($name) {
 		<div class="col-6 col-md-4 col-lg-2">
 			<div class="card h-100">
 				<div class="card-header py-2">
-					<h6 class="mb-0 text-nowrap"><i class="fas fa-globe"></i> <?= __("DXCC Worked"); ?></h6>
+					<h6 class="mb-0 text-nowrap"><i class="fas fa-fire"></i> <?= __("Current Streak"); ?></h6>
 				</div>
 				<div class="card-body p-0">
-					<h4 class="fw-bold mb-0 px-3 py-2"><?php echo $total_countries; ?></h4>
+					<h4 class="fw-bold mb-0 px-3 py-2"><?php echo $current_streak . ' ' . __("days"); ?></h4>
 				</div>
 			</div>
 		</div>

--- a/application/views/dashboard/index.php
+++ b/application/views/dashboard/index.php
@@ -309,10 +309,10 @@ function echo_table_header_col($name) {
 		<div class="col-6 col-md-4 col-lg-2">
 			<div class="card h-100">
 				<div class="card-header py-2">
-					<h6 class="mb-0 text-nowrap"><i class="fas fa-map-marker-alt"></i> <?= __("DXCC Needed"); ?></h6>
+					<h6 class="mb-0 text-nowrap"><i class="fas fa-users"></i> <?= __("Unique Callsigns"); ?></h6>
 				</div>
 				<div class="card-body p-0">
-					<h4 class="fw-bold mb-0 px-3 py-2"><?php echo $total_countries_needed; ?></h4>
+					<h4 class="fw-bold mb-0 px-3 py-2"><?php echo $unique_callsigns; ?></h4>
 				</div>
 			</div>
 		</div>

--- a/application/views/dashboard/index.php
+++ b/application/views/dashboard/index.php
@@ -302,7 +302,7 @@ function echo_table_header_col($name) {
 					<h6 class="mb-0 text-nowrap"><i class="fas fa-fire"></i> <?= __("Current Streak"); ?></h6>
 				</div>
 				<div class="card-body p-0">
-					<h4 class="fw-bold mb-0 px-3 py-2"><?php echo $current_streak . ' ' . __("days"); ?></h4>
+					<h4 class="fw-bold mb-0 px-3 py-2"><a href="<?php echo site_url('dayswithqso'); ?>" class="text-decoration-none"><?php echo $current_streak . ' ' . __("days"); ?></a></h4>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
New Cards showed redundant informations (DXCCs worked / needed are already in sidebar).
So this PR replaces them with:

- current streak
- Unique Calls worked